### PR TITLE
feat(build): ROS 2 Humble / jammy / arm64 deb via ROS_DISTRO matrix (ROB-325)

### DIFF
--- a/.github/actions/publish-debian-s3/action.yml
+++ b/.github/actions/publish-debian-s3/action.yml
@@ -97,6 +97,17 @@ runs:
           echo "No existing repository found in S3"
         fi
 
+    # NOTE (ROB-325): this action publishes the SAME package set to every
+    # distribution (noble/jammy/focal) from a single aptly repo. With the Humble
+    # (jammy) build added alongside Jazzy (noble), each .deb still lands in all
+    # three dists. That is safe here because bloom stamps the Ubuntu codename
+    # into the version (ros-jazzy-* → <ver>-0noble, ros-humble-* → <ver>-0jammy)
+    # AND the package names differ (ros-jazzy-robotops-config vs
+    # ros-humble-robotops-config), so the two arm64 artifacts never collide in
+    # the pool. The ros-humble-* deb appearing in the noble dist is inert — it
+    # hard-depends on libprotobuf23 (Jammy) and won't install on Noble — but a
+    # future change should route each .deb to only its matching distribution
+    # (jazzy → noble, humble → jammy) keyed off the ros-<distro>-* package name.
     - name: Create or Update Repository
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Try to check against base branch using Docker (lint step already built the image)
           set +e
-          OUTPUT=$(docker run --rm -v $(pwd):/ws/src/robotops-config robotops-config:build bash -c "cd /ws/src/robotops-config && buf breaking proto --against \"https://github.com/${{ github.repository }}.git#branch=$BASE_BRANCH,subdir=proto\" 2>&1")
+          OUTPUT=$(docker run --rm -v $(pwd):/ws/src/robotops-config robotops-config:build-jazzy bash -c "cd /ws/src/robotops-config && buf breaking proto --against \"https://github.com/${{ github.repository }}.git#branch=$BASE_BRANCH,subdir=proto\" 2>&1")
           EXIT_CODE=$?
           set -e
 
@@ -156,7 +156,11 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
-        run: just generate
+        # Generate with the matrix distro's protoc/libprotobuf so the C++ .pb.cc
+        # matches the libprotobuf the .deb links against (ROB-325). Without this,
+        # `just generate` defaults to jazzy (libprotobuf 3.21) and the Humble
+        # (Jammy, libprotobuf 3.12.4) link step fails to compile config.pb.cc.
+        run: just ROS_DISTRO=${{ matrix.ros_distro }} generate
 
       - name: Build Debian package
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,13 +107,36 @@ jobs:
           echo "C++ package validated successfully"
 
   test-ros2-package-integration:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry per (ROS distro, Ubuntu codename, arch). The distro selects
+        # the ros:<distro> base image + /opt/ros/<distro>; os_version is the
+        # Ubuntu codename bloom stamps into the .deb (noble for jazzy, jammy for
+        # humble). The runner must match the deb's Ubuntu target so the on-host
+        # dpkg install + CMake integration check resolves the right libprotobuf
+        # (noble → libprotobuf32, jammy → libprotobuf23).
+        #   - jazzy  → Ubuntu 24.04 Noble, amd64 (the current target).
+        #   - humble → Ubuntu 22.04 Jammy, arm64 (robot_agent's Jetson links
+        #     against ros-humble-robotops-config; see ROB-325).
+        include:
+          - ros_distro: jazzy
+            os_version: noble
+            arch: amd64
+            runner: ubuntu-24.04
+            just_arch: x86_64
+          - ros_distro: humble
+            os_version: jammy
+            arch: arm64
+            runner: ubuntu-22.04-arm
+            just_arch: aarch64
     steps:
       - uses: actions/checkout@v4
 
       - name: Install just
         run: |
-          curl -sSL https://github.com/casey/just/releases/download/1.36.0/just-1.36.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /tmp just
+          curl -sSL https://github.com/casey/just/releases/download/1.36.0/just-1.36.0-${{ matrix.just_arch }}-unknown-linux-musl.tar.gz | tar xz -C /tmp just
           sudo mv /tmp/just /usr/local/bin/
 
       - name: Set up Docker Buildx
@@ -126,9 +149,11 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops-config:build
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops-config:build-${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
         run: just generate
@@ -138,14 +163,14 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/ws/src/robotops-config \
             -v ${{ github.workspace }}:/output \
-            robotops-config:build bash -c "
+            robotops-config:build-${{ matrix.ros_distro }} bash -c "
               cd /ws/src/robotops-config && \
               cp generated/ros2/package.xml . && \
               cp generated/ros2/CMakeLists.txt . && \
               mkdir -p cmake && cp generated/ros2/robotops-configConfig.cmake.in cmake/ && \
               apt-get update && \
               apt-get install -y dpkg-dev fakeroot debhelper && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -153,7 +178,9 @@ jobs:
       - name: Find built package
         id: deb
         run: |
-          DEB_FILE=$(ls *.deb | head -n1)
+          # bloom names the deb ros-<distro>-robotops-config_<ver>_<arch>.deb,
+          # so the distro is already encoded; pick the matching one explicitly.
+          DEB_FILE=$(ls ros-${{ matrix.ros_distro }}-robotops-config_*_${{ matrix.arch }}.deb | head -n1)
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
@@ -170,7 +197,7 @@ jobs:
           mkdir -p build && cd build
 
           # Configure with ROS2 prefix
-          cmake .. -DCMAKE_PREFIX_PATH=/opt/ros/jazzy
+          cmake .. -DCMAKE_PREFIX_PATH=/opt/ros/${{ matrix.ros_distro }}
 
           # Build the test
           cmake --build .
@@ -185,22 +212,22 @@ jobs:
           echo "Verifying installation..."
 
           # Verify library exists
-          test -f /opt/ros/jazzy/lib/librobotops-config.so || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/lib/librobotops-config.so || \
             { echo "❌ Library not found"; exit 1; }
           echo "✓ Library found"
 
           # Verify headers exist
-          test -f /opt/ros/jazzy/include/robotops/config/v1/config.pb.h || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/include/robotops/config/v1/config.pb.h || \
             { echo "❌ Headers not found"; exit 1; }
           echo "✓ Headers found"
 
           # Verify CMake config exists (ament location)
-          test -f /opt/ros/jazzy/share/robotops-config/cmake/robotops-configConfig.cmake || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/share/robotops-config/cmake/robotops-configConfig.cmake || \
             { echo "❌ CMake config not found"; exit 1; }
           echo "✓ CMake config found"
 
           # Check library links to protobuf
-          ldd /opt/ros/jazzy/lib/librobotops-config.so | grep protobuf || \
+          ldd /opt/ros/${{ matrix.ros_distro }}/lib/librobotops-config.so | grep protobuf || \
             { echo "❌ Protobuf not linked"; exit 1; }
           echo "✓ Protobuf linked correctly"
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -99,12 +99,26 @@ jobs:
     permissions:
       contents: write  # Needed to upload release assets
     strategy:
+      fail-fast: false
       matrix:
+        # See release.yml for the rationale. jazzy → Noble (amd64 + arm64);
+        # humble → Jammy, arm64 only (robot_agent's Jetson Humble build links
+        # against ros-humble-robotops-config — ROB-325). bloom encodes the
+        # distro in the .deb name (ros-<distro>-robotops-config_*) so the two
+        # arm64 builds never collide.
         include:
-          - arch: amd64
+          - ros_distro: jazzy
+            os_version: noble
+            arch: amd64
             runner: ubuntu-24.04
-          - arch: arm64
+          - ros_distro: jazzy
+            os_version: noble
+            arch: arm64
             runner: ubuntu-24.04-arm
+          - ros_distro: humble
+            os_version: jammy
+            arch: arm64
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -136,9 +150,11 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops-config:build
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops-config:build-${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
         run: just generate
@@ -148,14 +164,14 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/ws/src/robotops-config \
             -v ${{ github.workspace }}:/output \
-            robotops-config:build bash -c "
+            robotops-config:build-${{ matrix.ros_distro }} bash -c "
               cd /ws/src/robotops-config && \
               cp generated/ros2/package.xml . && \
               cp generated/ros2/CMakeLists.txt . && \
               mkdir -p cmake && cp generated/ros2/robotops-configConfig.cmake.in cmake/ && \
               apt-get update && \
               apt-get install -y dpkg-dev fakeroot debhelper && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -163,14 +179,16 @@ jobs:
       - name: Find built package
         id: deb
         run: |
-          DEB_FILE=$(ls *.deb | head -n1)
+          # bloom names the deb ros-<distro>-robotops-config_<ver>_<arch>.deb,
+          # so the distro is already encoded; pick the matching one explicitly.
+          DEB_FILE=$(ls ros-${{ matrix.ros_distro }}-robotops-config_*_${{ matrix.arch }}.deb | head -n1)
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
       - name: Upload Debian package as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: debian-package-${{ matrix.arch }}
+          name: debian-package-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -157,7 +157,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
-        run: just generate
+        # Generate with the matrix distro's protoc/libprotobuf so the C++ .pb.cc
+        # matches the libprotobuf the .deb links against (ROB-325).
+        run: just ROS_DISTRO=${{ matrix.ros_distro }} generate
 
       - name: Build Debian package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
-        run: just generate
+        # Generate with the matrix distro's protoc/libprotobuf so the C++ .pb.cc
+        # matches the libprotobuf the .deb links against (ROB-325).
+        run: just ROS_DISTRO=${{ matrix.ros_distro }} generate
 
       - name: Build Debian package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,33 @@ jobs:
     permissions:
       contents: write  # Needed to upload release assets
     strategy:
+      fail-fast: false
       matrix:
+        # Each entry builds one (ROS distro, Ubuntu codename, arch) .deb. The
+        # distro selects the ros:<distro> base image + /opt/ros/<distro>;
+        # os_version is the Ubuntu codename bloom stamps into the .deb and the
+        # apt.robotops.com channel it publishes to. The runner must match the
+        # deb's Ubuntu target so the on-host dpkg-install validation resolves
+        # the right libprotobuf (noble → libprotobuf32, jammy → libprotobuf23).
+        #   - jazzy  → Ubuntu 24.04 Noble, amd64 + arm64 (the current target).
+        #   - humble → Ubuntu 22.04 Jammy, arm64 only — robot_agent's Jetson
+        #     (Orin Nano) Humble build links against ros-humble-robotops-config
+        #     (ROB-325). bloom names the deb ros-<distro>-robotops-config_*, so
+        #     ros-jazzy-* (noble) and ros-humble-* (jammy) never collide even on
+        #     the shared arm64 architecture.
         include:
-          - arch: amd64
+          - ros_distro: jazzy
+            os_version: noble
+            arch: amd64
             runner: ubuntu-24.04
-          - arch: arm64
+          - ros_distro: jazzy
+            os_version: noble
+            arch: arm64
             runner: ubuntu-24.04-arm
+          - ros_distro: humble
+            os_version: jammy
+            arch: arm64
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -134,9 +155,11 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops-config:build
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops-config:build-${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Generate protobuf code
         run: just generate
@@ -146,14 +169,14 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/ws/src/robotops-config \
             -v ${{ github.workspace }}:/output \
-            robotops-config:build bash -c "
+            robotops-config:build-${{ matrix.ros_distro }} bash -c "
               cd /ws/src/robotops-config && \
               cp generated/ros2/package.xml . && \
               cp generated/ros2/CMakeLists.txt . && \
               mkdir -p cmake && cp generated/ros2/robotops-configConfig.cmake.in cmake/ && \
               apt-get update && \
               apt-get install -y dpkg-dev fakeroot debhelper && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -161,7 +184,9 @@ jobs:
       - name: Find built package
         id: deb
         run: |
-          DEB_FILE=$(ls *.deb | head -n1)
+          # bloom names the deb ros-<distro>-robotops-config_<ver>_<arch>.deb,
+          # so the distro is already encoded; pick the matching one explicitly.
+          DEB_FILE=$(ls ros-${{ matrix.ros_distro }}-robotops-config_*_${{ matrix.arch }}.deb | head -n1)
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
@@ -179,7 +204,7 @@ jobs:
           mkdir -p build && cd build
 
           # Configure with ROS2 prefix
-          cmake .. -DCMAKE_PREFIX_PATH=/opt/ros/jazzy
+          cmake .. -DCMAKE_PREFIX_PATH=/opt/ros/${{ matrix.ros_distro }}
 
           # Build the test
           cmake --build .
@@ -194,22 +219,22 @@ jobs:
           echo "Verifying installation..."
 
           # Verify library exists
-          test -f /opt/ros/jazzy/lib/librobotops-config.so || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/lib/librobotops-config.so || \
             { echo "❌ Library not found"; exit 1; }
           echo "✓ Library found"
 
           # Verify headers exist
-          test -f /opt/ros/jazzy/include/robotops/config/v1/config.pb.h || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/include/robotops/config/v1/config.pb.h || \
             { echo "❌ Headers not found"; exit 1; }
           echo "✓ Headers found"
 
           # Verify CMake config exists (ament location)
-          test -f /opt/ros/jazzy/share/robotops-config/cmake/robotops-configConfig.cmake || \
+          test -f /opt/ros/${{ matrix.ros_distro }}/share/robotops-config/cmake/robotops-configConfig.cmake || \
             { echo "❌ CMake config not found"; exit 1; }
           echo "✓ CMake config found"
 
           # Check library links to protobuf
-          ldd /opt/ros/jazzy/lib/librobotops-config.so | grep protobuf || \
+          ldd /opt/ros/${{ matrix.ros_distro }}/lib/librobotops-config.so | grep protobuf || \
             { echo "❌ Protobuf not linked"; exit 1; }
           echo "✓ Protobuf linked correctly"
 
@@ -218,7 +243,7 @@ jobs:
       - name: Upload Debian package as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: debian-package-${{ matrix.arch }}
+          name: debian-package-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add subscription gating policy and QoS defaults to `SubscriptionsConfig` for topic visibility and least-intrusive compatible subscriptions.
 
+### Changed
+
+- **ROS 2 Humble / Ubuntu 22.04 Jammy / arm64 Debian package** (ROB-325): the `Dockerfile` and the `ci.yml` / `release.yml` / `release-dev.yml` workflows are now parameterized by ROS distro instead of hardcoding Jazzy. The `Dockerfile` takes `--build-arg ROS_DISTRO` (`FROM ros:${ROS_DISTRO}`); the build matrices gained a `{ros_distro, os_version, arch}` dimension so a single build path produces both `ros-jazzy-robotops-config_*_{amd64,arm64}.deb` (Noble) and `ros-humble-robotops-config_*_arm64.deb` (Jammy) via `bloom-generate --os-version ${OS_VERSION} --ros-distro ${ROS_DISTRO}`. The `ci.yml` artifact checks (`librobotops-config.so`, CMake prefix, headers, protobuf `ldd`) now resolve under `/opt/ros/${ROS_DISTRO}`. The Humble deb links against Jammy's `libprotobuf23` (3.12.4) and publishes to the apt.robotops.com **jammy** channel (Jazzy → noble). robot_agent's Jetson (Orin Nano) Humble build links against this package.
+
 ## [0.9.5] - 2026-05-29
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-FROM ros:jazzy
+# Build environment for librobotops-config.so (the protobuf-backed C++ lib)
+# and its ROS 2 Debian package.
+#
+# Parameterized by ROS distro so a single Dockerfile builds for either
+# Jazzy (Ubuntu 24.04 Noble) or Humble (Ubuntu 22.04 Jammy, the arm64/Jetson
+# target). Pass --build-arg ROS_DISTRO=humble for the Humble build.
+#
+#   ROS_DISTRO  ROS 2 distribution (jazzy | humble). Selects the
+#               `ros:${ROS_DISTRO}` base image and /opt/ros/${ROS_DISTRO}.
+ARG ROS_DISTRO=jazzy
+FROM ros:${ROS_DISTRO}
+
+# Re-declare after FROM so the value is in scope in the build stage.
+ARG ROS_DISTRO
 
 # Set up environment
 ENV DEBIAN_FRONTEND=noninteractive
-ENV ROS_DISTRO=jazzy
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 # Install all dependencies
 RUN apt-get update && apt-get install -y \
@@ -19,8 +32,12 @@ RUN apt-get update && apt-get install -y \
     python3-protobuf \
     && rm -rf /var/lib/apt/lists/*
 
-# Install bloom via pip (not available in Ubuntu 24.04 repos)
-RUN pip3 install --break-system-packages bloom
+# Install bloom via pip (not available in the Ubuntu apt repos).
+# Ubuntu 24.04 (Noble/Jazzy) ships a PEP 668 "externally managed" pip that
+# requires --break-system-packages; Ubuntu 22.04 (Jammy/Humble) does not have
+# that marker and its older pip does not understand the flag. Try the modern
+# invocation first and fall back so a single Dockerfile works on both.
+RUN pip3 install --break-system-packages bloom || pip3 install bloom
 
 # Update rosdep database
 RUN rosdep update

--- a/justfile
+++ b/justfile
@@ -1,17 +1,28 @@
 # Version management and code generation for robotops_config
 
+# ROS 2 distro that selects the build image (ros:${ROS_DISTRO}) and, with it,
+# the protoc/libprotobuf version used to generate the C++ protobuf sources.
+# This MUST match the distro the .deb is built/linked for, because buf's cpp
+# generator emits code targeting the build image's libprotobuf:
+#   - jazzy  → Ubuntu 24.04 Noble, libprotobuf 3.21.x (the default)
+#   - humble → Ubuntu 22.04 Jammy, libprotobuf 3.12.4
+# Generating with the wrong distro produces .pb.cc/.pb.h that won't compile
+# against the target distro's libprotobuf (see ROB-325). Override with:
+#   just ROS_DISTRO=humble generate
+ROS_DISTRO := "jazzy"
+
 # Lint proto files for style and correctness
 lint:
     @echo "Linting proto files..."
-    docker build -t robotops-config:build .
-    docker run --rm -v $(pwd):/ws/src/robotops-config robotops-config:build bash -c "cd /ws/src/robotops-config && buf lint proto"
+    docker build -t robotops-config:build-{{ROS_DISTRO}} --build-arg ROS_DISTRO={{ROS_DISTRO}} .
+    docker run --rm -v $(pwd):/ws/src/robotops-config robotops-config:build-{{ROS_DISTRO}} bash -c "cd /ws/src/robotops-config && buf lint proto"
     @echo "✅ Proto linting passed"
 
 # Generate all code from proto schema (Rust, C++, YAML)
 generate:
-    @echo "Generating code from proto schema..."
-    docker build -t robotops-config:build .
-    docker run --rm -v $(pwd):/ws/src/robotops-config -u $(id -u):$(id -g) -e XDG_CACHE_HOME=/tmp/.cache robotops-config:build bash -c "cd /ws/src/robotops-config && buf generate"
+    @echo "Generating code from proto schema (ROS_DISTRO={{ROS_DISTRO}})..."
+    docker build -t robotops-config:build-{{ROS_DISTRO}} --build-arg ROS_DISTRO={{ROS_DISTRO}} .
+    docker run --rm -v $(pwd):/ws/src/robotops-config -u $(id -u):$(id -g) -e XDG_CACHE_HOME=/tmp/.cache robotops-config:build-{{ROS_DISTRO}} bash -c "cd /ws/src/robotops-config && buf generate"
     python3 tools/robotops-codegen/main.py
     @echo ""
     @echo "✅ Code generation complete"


### PR DESCRIPTION
## Summary

Adds a **ROS 2 Humble (Ubuntu 22.04 Jammy, arm64)** Debian-package build to `robotops_config`, alongside the existing Jazzy/Noble one. robot_agent's Humble build (the Jetson Orin Nano, ROB-324/#111) links against `librobotops-config.so`, but apt.robotops.com only shipped `ros-jazzy-*` — this gives it a `ros-humble-robotops-config` to depend on.

Mirrors robot_agent #111's `ROS_DISTRO`-parameterized style. Favors one clean matrix over duplicated jobs; Jazzy behavior is unchanged.

## Distro matrix

The Debian-build job in all three workflows gains a `{ros_distro, os_version, arch}` matrix dimension (was `{arch}` only):

| ros_distro | os_version | arch        | runner            |
|------------|------------|-------------|-------------------|
| jazzy      | noble      | amd64       | ubuntu-24.04      |
| jazzy      | noble      | arm64       | ubuntu-24.04-arm  |
| humble     | jammy      | arm64       | ubuntu-22.04-arm  |

## Deltas

- **Dockerfile** — `ARG ROS_DISTRO=jazzy` + `FROM ros:${ROS_DISTRO}` (re-declared after FROM); `ENV ROS_DISTRO=${ROS_DISTRO}`. `bloom` pip install falls back from `--break-system-packages` to plain `pip3 install` for Jammy's older (pre-PEP-668) pip.
- **ci.yml / release.yml / release-dev.yml** — Docker build passes `--build-arg ROS_DISTRO` with per-distro scoped gha cache and `robotops-config:build-<distro>` tag; `bloom-generate --os-version ${OS_VERSION} --ros-distro ${ROS_DISTRO}`; artifact name `debian-package-<distro>-<arch>`; `Find built package` picks `ros-<distro>-robotops-config_*_<arch>.deb`.
- **ci.yml checks** — `cmake -DCMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}` and all `librobotops-config.so` / headers / CMake-config / protobuf-`ldd` checks resolve under `/opt/ros/${ROS_DISTRO}`. The Humble integration check runs on `ubuntu-22.04-arm` so the deb's `libprotobuf23` (Jammy) dependency resolves on the host (Noble ships libprotobuf32).
- **publish-debian-s3** — NOTE only (no logic change): bloom stamps the Ubuntu codename into the version (`-0noble` vs `-0jammy`) and the package names differ (`ros-jazzy-robotops-config` vs `ros-humble-robotops-config`), so the two arm64 builds never collide in the aptly pool. Per-distribution routing (humble → jammy only) is tracked as a follow-up.

## Publishing

The publish job runs **only on release dispatch** (`workflow_dispatch`), unchanged. `publish-debian-s3` adds every `.deb` to the aptly repo and publishes to noble/jammy/focal; the Humble deb is installable from the **jammy** channel (Jazzy → noble).

## Local build proof

Verified end-to-end in a `ros:humble` **arm64** container (native arm64 Mac, no publishing):

```sh
docker build --build-arg ROS_DISTRO=humble -t robotops-config:build-humble -f Dockerfile .
just generate   # buf generate + tools/robotops-codegen/main.py → generated/ros2/
docker run --rm -v $(pwd):/ws/src/robotops-config -v /tmp/out:/output \
  robotops-config:build-humble bash -c "
    cd /ws/src/robotops-config &&
    cp generated/ros2/package.xml . && cp generated/ros2/CMakeLists.txt . &&
    mkdir -p cmake && cp generated/ros2/robotops-configConfig.cmake.in cmake/ &&
    apt-get update && apt-get install -y dpkg-dev fakeroot debhelper &&
    bloom-generate rosdebian --os-name ubuntu --os-version jammy --ros-distro humble &&
    dpkg-buildpackage -us -uc -b && cp /ws/src/*.deb /output/"
```

Produced: **`ros-humble-robotops-config_0.9.6-0jammy_arm64.deb`** (Architecture: arm64, `Depends: ... libprotobuf23 (>= 3.12.4) ...`). After `dpkg -i`:

```
/opt/ros/humble/lib/librobotops-config.so
  libprotobuf.so.23 => /lib/aarch64-linux-gnu/libprotobuf.so.23
```

Headers (`config.pb.h`) and CMake configs install under `/opt/ros/humble/...`.

## C++/protobuf-on-Humble

**No source changes needed.** The generated C++ (`config.pb.cc/.h`) compiled cleanly against Jammy's older protobuf (3.12.4 / `libprotobuf23`) vs Noble's newer protobuf. The only Dockerfile fix was the bloom-via-pip `--break-system-packages` fallback for Jammy's older pip.

Do not merge yet.