### PR TITLE
fix(robotops_config): validate config examples against generated protos (ROB-237)

### DIFF
--- a/justfile
+++ b/justfile
@@ -211,7 +211,7 @@ validate-examples:
     set -euo pipefail
 
     # Check if generated Python protobuf exists
-    if [ ! -f "generated/sdks/python/robotops/config/v1/config_pb2.py" ]; then
+    if [ ! -f "generated/sdks/python/robotops/config/v1/config_pb2.py" ] && [ ! -f "out/proto/robotops/config/v1/config_pb2.py" ]; then
         echo "Error: Python protobuf files not found. Run 'just generate' first."
         exit 1
     fi

--- a/tools/validate-examples.py
+++ b/tools/validate-examples.py
@@ -12,11 +12,14 @@ from pathlib import Path
 from google.protobuf import text_format
 from google.protobuf.json_format import ParseDict, ParseError
 
-# Add generated protobuf to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "generated" / "sdks" / "python"))
+# Add generated protobuf outputs to path. Older checkouts track Python output in
+# out/proto/, while `buf generate` writes it under generated/sdks/python/.
+repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(repo_root / "generated" / "sdks" / "python"))
+sys.path.insert(0, str(repo_root / "out" / "proto"))
 
 try:
-    from proto.robotops.config.v1 import config_pb2
+    from robotops.config.v1 import config_pb2  # type: ignore[reportMissingImports]
 except ImportError:
     print("Error: Could not import generated protobuf types.")
     print("Run 'just generate' first to generate Python protobuf code.")

--- a/tools/validate-examples.py
+++ b/tools/validate-examples.py
@@ -6,24 +6,40 @@ This script ensures example configurations conform to the protobuf schema
 by attempting to parse them into the generated protobuf message types.
 """
 
+import importlib.util
 import sys
-import yaml
 from pathlib import Path
-from google.protobuf import text_format
+
+import yaml
 from google.protobuf.json_format import ParseDict, ParseError
 
-# Add generated protobuf outputs to path. Older checkouts track Python output in
-# out/proto/, while `buf generate` writes it under generated/sdks/python/.
-repo_root = Path(__file__).parent.parent
-sys.path.insert(0, str(repo_root / "generated" / "sdks" / "python"))
-sys.path.insert(0, str(repo_root / "out" / "proto"))
 
-try:
-    from robotops.config.v1 import config_pb2  # type: ignore[reportMissingImports]
-except ImportError:
+repo_root = Path(__file__).parent.parent
+
+
+def load_config_pb2():
+    """Load the generated Config protobuf module from whichever output exists."""
+    candidates = [
+        repo_root / "generated" / "sdks" / "python" / "robotops" / "config" / "v1" / "config_pb2.py",
+        repo_root / "out" / "proto" / "robotops" / "config" / "v1" / "config_pb2.py",
+    ]
+
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location("robotops_config_pb2", candidate)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
     print("Error: Could not import generated protobuf types.")
     print("Run 'just generate' first to generate Python protobuf code.")
     sys.exit(1)
+
+
+config_pb2 = load_config_pb2()
 
 
 def snake_to_camel(snake_str: str) -> str:


### PR DESCRIPTION
### Summary\n- Make the example validator accept the generated protobuf package layout used in this checkout.\n- Keep the justfile check aligned with the available Python output locations.\n- Remove the stale import path assumption that broke Validating 3 example file(s)...

Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/high-bandwidth.yaml...
  ✅ Valid
Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/low-resource.yaml...
  ✅ Valid
Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/nav2.yaml...
  ✅ Valid

✅ All 3 example files are valid locally.\n\n### Verification\n- Validating 3 example file(s)...

Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/high-bandwidth.yaml...
  ✅ Valid
Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/low-resource.yaml...
  ✅ Valid
Validating /home/q/workspace/robotops/robotops_config/robotops_config.worktrees/ROB-237/examples/nav2.yaml...
  ✅ Valid

✅ All 3 example files are valid ✅\n- Expected version: 0.9.4

OK: examples/high-bandwidth.yaml
OK: examples/low-resource.yaml
OK: examples/nav2.yaml
OK: proto/robotops/config/v1/config.proto
OK: generated/yaml/default.yaml
OK: test/cmake_integration/test.cpp

All versions match: 0.9.4 ✅\n\n### Notes\n- AI-assisted contribution; reviewed for correctness and repository policy.