### PR TITLE
release: sync config schema_version to 0.10.0 (ROB-408)

### DIFF
--- a/examples/high-bandwidth.yaml
+++ b/examples/high-bandwidth.yaml
@@ -4,7 +4,7 @@
 # Aggressive sampling reduces trace and storage overhead while maintaining
 # visibility into critical control paths.
 
-schema_version: "0.9.9"
+schema_version: "0.10.0"
 
 tracing:
   enabled: true

--- a/examples/low-resource.yaml
+++ b/examples/low-resource.yaml
@@ -4,7 +4,7 @@
 # Reduces buffer sizes, sampling rates, and collection frequency to
 # minimize overhead while maintaining essential observability.
 
-schema_version: "0.9.9"
+schema_version: "0.10.0"
 
 tracing:
   enabled: true

--- a/examples/nav2.yaml
+++ b/examples/nav2.yaml
@@ -4,7 +4,7 @@
 # Prioritizes tracing for navigation-critical topics while reducing
 # overhead for high-frequency sensor data.
 
-schema_version: "0.9.9"
+schema_version: "0.10.0"
 
 tracing:
   enabled: true

--- a/proto/robotops/config/v1/config.proto
+++ b/proto/robotops/config/v1/config.proto
@@ -11,7 +11,7 @@ package robotops.config.v1;
 message Config {
   // Schema version for configuration compatibility checking.
   // Components validate that the major version matches their supported version.
-  // @default "0.9.9"
+  // @default "0.10.0"
   string schema_version = 1;
 
   // Robot identity and fleet organization.

--- a/test/cmake_integration/test.cpp
+++ b/test/cmake_integration/test.cpp
@@ -5,7 +5,7 @@
 int main() {
     // Test that we can create a protobuf message
     robotops::config::v1::Config config;
-    config.set_schema_version("0.9.9");
+    config.set_schema_version("0.10.0");
 
     // Test that defaults.hpp is accessible and functions work
     robotops::config::v1::Config default_config = robotops::config::v1::CreateDefaultConfig();


### PR DESCRIPTION
Syncs proto @default schema_version + examples + regenerated artifacts to VERSION 0.10.0. (The version-bump-required check will flag 'proto changed without VERSION bump' — expected, VERSION was already bumped to 0.10.0 in #126; it's not a required check.) Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4